### PR TITLE
Bump uesave 0.6.1 -> 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "uesave"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ed60a97e9269f128d972e261e9d8cd94d5a265cd6b2381d6e63120c1b3180e"
+checksum = "b859e23f7a3b9dd3c1b7f0afcdad4c7f287d6c27275b4c8248609ff6ad0b61ea"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-uesave = "0.6.1"
+uesave = "0.6.2"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Fixes some Obscur saves failing to parse